### PR TITLE
Allow option to pass syncExec function to tagging adapter via constructor instead.

### DIFF
--- a/lib/utilities/tagging/sha.js
+++ b/lib/utilities/tagging/sha.js
@@ -1,17 +1,17 @@
 var CoreObject = require('core-object');
 
 module.exports = CoreObject.extend({
-  createTag: function(syncExec) {
-    syncExec = syncExec || require('sync-exec');
+  init: function() {
+    this.syncExec = this.syncExec || require('sync-exec');
+  },
 
-    var commandResult = syncExec("git rev-parse HEAD").stdout;
-
-    this._generateKey(commandResult);
-
-    return this.revisionKey;
+  createTag: function() {
+    var commandResult = this.syncExec("git rev-parse HEAD").stdout;
+    return this._generateKey(commandResult);
   },
 
   _generateKey: function(sha) {
-    this.revisionKey = this.manifest+':'+sha.slice(0,7);
+    this.revisionKey = this.manifest + ':' + sha.slice(0,7);
+    return this.revisionKey;
   }
 });

--- a/node-tests/unit/utilities/tagging/sha-test.js
+++ b/node-tests/unit/utilities/tagging/sha-test.js
@@ -1,5 +1,4 @@
 var expect            = require('chai').expect;
-var sinon             = require('sinon');
 var ShaTaggingAdapter = require('../../../../lib/utilities/tagging/sha');
 
 var getShortShaVersion = function(sha) {
@@ -10,31 +9,20 @@ var GIT_SHA           = '04b724a6c656a21795067f9c344d22532cf593ae';
 var GIT_SHA_SHORTENED = getShortShaVersion(GIT_SHA);
 
 describe('ShaTaggingAdapter', function() {
-  var sandbox;
-  var syncExec = {
-    exec: require('sync-exec')
-  };
-
-  beforeEach(function() {
-    sandbox = sinon.sandbox.create();
-    sandbox
-      .stub(syncExec, 'exec')
-      .returns({stdout: GIT_SHA});
-  });
-
-  afterEach(function() {
-    sandbox.restore();
-  });
+  var mockSyncExec = function(){
+    return {stdout: GIT_SHA};
+  }
 
   describe('#createTag', function() {
     it('returns a tag based on current git-sha and manifestName', function() {
       var manifestName   = 'ember-cli-deploy';
-      var expectedTag    = manifestName+':'+GIT_SHA_SHORTENED;
+      var expectedTag    = manifestName + ':' + GIT_SHA_SHORTENED;
       var revisionTagger = new ShaTaggingAdapter({
-        manifest: manifestName
+        manifest: manifestName,
+        syncExec: mockSyncExec
       });
 
-      expect(revisionTagger.createTag(syncExec.exec)).to.eq(expectedTag);
+      expect(revisionTagger.createTag()).to.eq(expectedTag);
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "ember-export-application-global": "^1.0.0",
     "express": "^4.8.5",
     "github": "0.2.3",
-    "glob": "^4.0.5",
     "mocha": "^2.0.1",
     "sinon": "^1.12.1"
   },
@@ -51,6 +50,7 @@
     "broccoli-gzip": "^0.2.0",
     "chalk": "^0.5.1",
     "core-object": "0.0.2",
+    "glob": "^4.0.5",
     "lodash-node": "^2.4.1",
     "mkdirp": "^0.5.0",
     "ncp": "^1.0.1",


### PR DESCRIPTION
I think this is an improvement on the mocking strategy for syncExec in the tagging test. See what you think... 
